### PR TITLE
CAS 3.0 Protocol Attribute return and method typo fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ Network Trash Folder
 Temporary Items
 .apdisk
 ###### MacOS ######
+
+#Jetbrains IDEs
+.idea

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Endpoint of CAS Server (eg. `'xxxx.casserver.com'`)
 - `protocol` - CAS server protocol, can be `'http'`, `'https'`) (default: `'https'`);
 - `version` - CAS protocol version can be `constant.CAS_VERSION_2_0`, `constant.CAS_VERSION_3_0` (default: `constant.CAS_VERSION_3_0`)
 - `validation_proxy_path` - Proxy path for application to make call to CAS server to validate ticket (**!! Related to CORS issue !!**)
-- `return_attributes` - Whether custom attributes from CAS are returned, can be `true` or `false`, (default: `true`)
+- `return_attributes` - Whether custom attributes from the CAS 3.0 protocol are returned, can be `true` or `false`, (default: `true`)
 
 ### Start authorization flow (Login)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Endpoint of CAS Server (eg. `'xxxx.casserver.com'`)
 - `protocol` - CAS server protocol, can be `'http'`, `'https'`) (default: `'https'`);
 - `version` - CAS protocol version can be `constant.CAS_VERSION_2_0`, `constant.CAS_VERSION_3_0` (default: `constant.CAS_VERSION_3_0`)
 - `validation_proxy_path` - Proxy path for application to make call to CAS server to validate ticket (**!! Related to CORS issue !!**)
+- `return_attributes` - Whether custom attributes from CAS are returned, can be `true` or `false`, (default: `true`)
 
 ### Start authorization flow (Login)
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const defaultOptions = {
   path: '/cas',
   version: constant.CAS_VERSION_3_0,
   validation_proxy_path: '',
+  return_attributes: true,
 };
 
 class CasClient {
@@ -29,6 +30,8 @@ class CasClient {
       options.validation_proxy_path || defaultOptions.validation_proxy_path;
 
     this.redirectUrl = util.getCurrentUrl();
+
+    this.return_attributes = options.return_attributes !== false;
   }
 
   auth(gateway = false) {
@@ -58,12 +61,15 @@ class CasClient {
   }
 
   _getSuccessResponse(user, attributes) {
-    return {
+    let response = {
       currentUrl: window.location.origin + window.location.pathname,
       currentPath: window.location.pathname,
       user: user,
-      attributes: attributes,
     };
+    if (this.return_attributes) {
+      response.attributes = attributes;
+    }
+    return response;
   }
 
   _validateTicket(ticket, resolve, reject) {

--- a/src/index.js
+++ b/src/index.js
@@ -135,8 +135,10 @@ class CasClient {
                         if (json.serviceResponse.authenticationSuccess) {
                           let user =
                             json.serviceResponse.authenticationSuccess.user;
-                          let attributes =
-                            json.serviceResponse.authenticationSuccess.attributes;
+                          let attributes = null;
+                          if (json.serviceResponse.authenticationSuccess.attributes) {
+                            attributes = json.serviceResponse.authenticationSuccess.attributes;
+                          }
                           this._handleSuccessValidate(resolve, user, attributes);
                         } else {
                           this._handleFailsValidate(reject, {


### PR DESCRIPTION
I've implemented an option for the CAS 3.0 protocol to allow/disallow the return of custom attributes, as well as fixed typos in some of your methods regarding the spelling of the word "Validate".

This change would allow authentication workflows that occur over the CAS 3.0 protocol to return the custom attributes specified in the CAS configuration to the client by default. As in many cases additional custom mapped attributes are stored there, like first name, last name, phone numbers, etc.

In the event that sensitive information is being sent over this context, returning the attributes can be disabled.

Please let me know if you have an issues with this implementation or would like to discuss further. There may be arguments to having this feature default to false instead of true.

Thank you!